### PR TITLE
Bump Spring -> 2.1.1, use "postgres" as dev username

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    spring (2.1.0)
+    spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 10000
-  username: arsood
+  username: postgres
 
 development:
   <<: *default


### PR DESCRIPTION
Updates the development setup so that the generic `postgres` is used as the username in development. I also needed to bump Spring to the latest to get it working.